### PR TITLE
Edits to readme

### DIFF
--- a/doc/provsql.md
+++ b/doc/provsql.md
@@ -42,7 +42,7 @@ planned.
 3. Finally, the `uuid-ossp` extension for PostgreSQL (on Debian-based
    systems, it is found in the `postgresql-contrib-9.x` package; on
    Homebrew, in the `ossp-uuid` package).
-s
+
 ## Installation
 
 1. Compile the code with `make`. If you have several installed versions

--- a/doc/provsql.md
+++ b/doc/provsql.md
@@ -66,9 +66,12 @@ planned.
 ## Testing your installation
 
 You can test your installation by running `make installcheck` as a
-PostgreSQL administrator user (if you do not want to run this as the
+PostgreSQL administrator user. If you do not want to run this as the
 default administrator user, you can make yourself a PostgreSQL
-administrator with ``ALTER USER your_login WITH SUPERUSER``).
+administrator with ``ALTER USER your_login WITH SUPERUSER``. This assumes that
+``your_login`` is a PostgreSQL user: on Debian-based Linux distributions, you
+can ensure this by running the command ``createuser your_login`` as the
+``postgresql`` user.
 
 ## Using ProvSQL
 


### PR DESCRIPTION
I fixed a typo in README, and I added more information about how to create the PostgreSQL user. You had previously told me this was standard, but this is the main thing that confused me again when trying to set up ProvSQL, I still think it would be worth it to add this. (That said, of course, feel free not to include that commit if you disagree.)