### PR TITLE
Updated Makefile.internal 

### DIFF
--- a/Makefile.internal
+++ b/Makefile.internal
@@ -17,6 +17,10 @@ EMPTY =
 REGRESS = $(EMPTY)
 REGRESS_OPTS = --load-extension=plpgsql --inputdir=test --outputdir=$(shell mktemp -d /tmp/tmp.provsqlXXXX) --schedule test/schedule
 
+OS := $(shell uname)
+ARCH := $(shell uname -m)
+
+
 # Additional options for pg_regress can be specified below, e.g., a port
 # number with EXTRA_REGRESS_OPTS = --port=5434
 EXTRA_REGRESS_OPTS =
@@ -45,11 +49,24 @@ PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
+
+
 %.o : %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
 %.o : %.cpp
+ifeq ($(OS), Darwin)
+ifeq ($(ARCH), arm64)
+	$(CXX) -I/opt/homebrew/Cellar/boost/$(shell cd /opt/homebrew/Cellar/boost/;ls -Art | tail -n 1;)/include -std=c++17 -Wno-register -fPIC $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $<
+endif
+ifeq ($(ARCH), x86_64)
+	$(CXX) -I/usr/local/include -std=c++17 -Wno-register -fPIC $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $<
+endif
+endif
+ifeq ($(OS), Linux)
 	$(CXX) -std=c++17 -Wno-register -fPIC $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $<
+endif
+
 
 VERSION     = $(shell $(PG_CONFIG) --version | awk '{print $$2}')
 PGVER_MAJOR = $(shell echo $(VERSION) | awk -F. '{ print ($$1 + 0) }')


### PR DESCRIPTION
With these changes in Makefile.internal, installation would be seamless for silicon Macs(ARM architecture), intel Macs, and Linux machines. I have tested for silicon Macs and linux (ARM based UBUNTU) VMs. It should work on intel Macs too.