### PR TITLE
Bug fix - build fail on Darwin

### DIFF
--- a/Makefile.internal
+++ b/Makefile.internal
@@ -52,7 +52,17 @@ PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
-all: $(DATA) $(MODULE_big)$(DLSUFFIX) test/schedule
+ifeq ($(OS), Darwin)
+PG_VERSION_NUM := $(shell $(PG_CONFIG) --version | sed 's/PostgreSQL //g' | cut -d. -f1)
+ifeq ($(shell expr $(PG_VERSION_NUM) \>= 16 ), 1)
+	LIB_SUFFIX = .dylib
+else
+	LIB_SUFFIX = .so
+endif
+all: $(DATA) $(MODULE_big)$(LIB_SUFFIX) test/schedule
+else
+all: $(DATA) $(MODULE_big).so test/schedule
+endif
 
 %.o : %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<


### PR DESCRIPTION
On Darwin the default suffix for dynamic library is `.dylib` unlike linux which has `.so` suffix. However, `Makefile.internal` has `all: $(DATA) $(MODULE_big).so test/schedule` i.e to satisfy all `$(MODULE_big).so` must be present. This is not required and thus the build fails. One simple solution to this can be a check which only requires `$(MODULE_big).dylib` as a requirement. On Darwin, since only a .dylib is built and copied to the postgres extensions directory this isn't a problem. Otherwise it retains the `.so` suffix i.e

```
ifeq ($(OS), Darwin)
all: $(DATA) $(MODULE_big).dylib test/schedule
else
all: $(DATA) $(MODULE_big).so test/schedule
endif
```

Tested working on Macos Tahoe 26.0.1 (25A362) on Macbook Air M1 (Arm64)